### PR TITLE
Detect duplicate letter occurrence when showing status

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a word game that started out as a clone of Wordle ([powerlanguage.co.uk/
 - [ ] Verify that entered word is a valid word
 - [ ] Animation for letter status display
 - [ ] Add styled components & clean up CSS
+- [x] Detect duplicate letters (only indicate letter in word for first occurrence unless it appears multiple times)
 - [x] Disallow typing new letters after word is guessed
 - [x] Show menu when game finished (used all guesses or solved)
 - [x] Remove tailwind

--- a/src/components/Wordle.js
+++ b/src/components/Wordle.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Word from '@utilities/Word';
-import { get, isNil, includes } from 'lodash'
+import { get, isNil } from 'lodash'
 import success from '@images/success.gif';
 import fail from '@images/fail.gif';
 class Wordle extends React.Component {
@@ -161,11 +161,25 @@ class Wordle extends React.Component {
     let currentLetter = get(this.state.words, `[${i}][${j}]`, null);
     if (isNil(currentLetter)) return 'empty';
 
-    if (includes(this.state.inputWord, currentLetter)) {
+    let pattern = new RegExp(currentLetter, 'g');
+    let occurrencesInInputWord = (this.state.inputWord.match(pattern) || []).length;
+    let substring = this.state.words[i].substring(0, j + 1);
+    
+    let occurrencesInSubstring = (substring.match(pattern) || []).length;
+
+    if (occurrencesInInputWord > 0) {
       if (this.state.inputWord[j] === currentLetter) {
         return 'exact';
       } else {
-        return 'in-word';
+        if (occurrencesInSubstring > 1) {
+          if (occurrencesInSubstring <= occurrencesInInputWord) {
+            return 'in-word';
+          } else {
+            return 'missing';
+          }
+        } else { 
+          return 'in-word';
+        }
       }
     } else {
       return 'missing';


### PR DESCRIPTION
If a letter occurs once, but you have more than one of that letter in your guess, only the first occurrence should indicate that it's in the word

If a letter occurs more than once, only indicate up to the number of occurrences

Examples:

- The word is `OBAMA`, you guess `BLOOM`
  - Only the first `O` should be indicated as in the word
- The word is `BLOOM`, you guess `OBAMO`
  - Both occurrences of `O` should be indicated as in the word